### PR TITLE
Fix: Prevent breaking external links by removing trailing slashes fro…

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,13 +39,11 @@ export async function onRequest(
     currentLocale = pathSegments[0];
   }
 
-  let modifiedHtml = html;
-
-  // If we have a currentLocale, modify the HTML to ensure all links
-  // have the correct locale prefix
-  if (currentLocale) {
-    modifiedHtml = ensureCorrectLocalePrefixesInHtmlLinks(html, currentLocale);
-  }
+  // Process HTML links to normalize external URLs and add locale prefixes when applicable
+  const modifiedHtml = ensureCorrectLocalePrefixesInHtmlLinks(
+    html,
+    currentLocale,
+  );
 
   // Return a new Response with the modified HTML
   return new Response(modifiedHtml, {
@@ -56,7 +54,7 @@ export async function onRequest(
 
 export const ensureCorrectLocalePrefixesInHtmlLinks = (
   html: string,
-  currentLocale: string,
+  currentLocale?: string,
 ) => {
   const $ = load(html);
 
@@ -65,13 +63,23 @@ export const ensureCorrectLocalePrefixesInHtmlLinks = (
   $("a").each(function () {
     let href = $(this).attr("href");
     // Skip if href is undefined, an external link, or written with a dot slash
-    if (
-      !href ||
-      href.startsWith("http") ||
-      href.startsWith("./") ||
-      href.startsWith("#")
-    )
+    if (!href || href.startsWith("./") || href.startsWith("#")) return;
+
+    // Remove trailing slashes from external/absolute URLs (like Wikipedia)
+    // to prevent breaking external links
+    if (href.startsWith("http")) {
+      try {
+        const urlObj = new URL(href);
+        // Only remove trailing slash if the path is not just "/"
+        if (href.endsWith("/") && urlObj.pathname !== "/") {
+          href = href.slice(0, -1);
+          $(this).attr("href", href);
+        }
+      } catch (e) {
+        // If URL parsing fails, leave the href unchanged
+      }
       return;
+    }
 
     const startsWithLocale = nonDefaultSupportedLocales.some(
       (locale) => href && href.startsWith(`/${locale}/`),


### PR DESCRIPTION
…m URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Locale prefixes are now consistently applied to HTML links when a locale is present, preserving leading-slash behavior.
  * External http/https links are normalized by removing redundant trailing slashes on non-root paths.
  * Relative, hash, undefined, and malformed links are safely ignored to prevent unintended changes.
  * If an external URL cannot be parsed it is left unchanged, improving link handling reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->