### PR TITLE
Replace invalid className HTML attributes

### DIFF
--- a/src/components/CircleButton/index.tsx
+++ b/src/components/CircleButton/index.tsx
@@ -22,18 +22,14 @@ export const CircleButton = ({
         onClick={onClick}
         aria-label={ariaLabel}
         href={href}
-        className={sharedClassName}
+        class={sharedClassName}
       >
         {children}
       </a>
     );
   }
   return (
-    <button
-      onClick={onClick}
-      aria-label={ariaLabel}
-      className={sharedClassName}
-    >
+    <button onClick={onClick} aria-label={ariaLabel} class={sharedClassName}>
       {children}
     </button>
   );

--- a/src/components/CodeEmbed/index.jsx
+++ b/src/components/CodeEmbed/index.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "preact/hooks";
-import { useLiveRegion } from '../hooks/useLiveRegion';
+import { useLiveRegion } from "../hooks/useLiveRegion";
 import CodeMirror, { EditorView } from "@uiw/react-codemirror";
 import { javascript } from "@codemirror/lang-javascript";
 import { cdnLibraryUrl, cdnSoundUrl } from "@/src/globals/globals";
@@ -38,14 +38,19 @@ export const CodeEmbed = (props) => {
   );
 
   let { previewWidth, previewHeight } = props;
-  const canvasMatch = /createCanvas\(\s*(\d+),\s*(\d+)\s*(?:,\s*(?:P2D|WEBGL)\s*)?\)/m.exec(initialCode);
+  const canvasMatch =
+    /createCanvas\(\s*(\d+),\s*(\d+)\s*(?:,\s*(?:P2D|WEBGL)\s*)?\)/m.exec(
+      initialCode,
+    );
   if (canvasMatch) {
     previewWidth = previewWidth || parseFloat(canvasMatch[1]);
     previewHeight = previewHeight || parseFloat(canvasMatch[2]);
   }
 
   // Quick hack to make room for DOM that gets added below the canvas by default
-  const domMatch = /create(Button|Select|P|Div|Input|ColorPicker)/.exec(initialCode);
+  const domMatch = /create(Button|Select|P|Div|Input|ColorPicker)/.exec(
+    initialCode,
+  );
   if (domMatch && previewHeight) {
     previewHeight += 100;
   }
@@ -87,15 +92,15 @@ export const CodeEmbed = (props) => {
     }
   }, []);
 
-  if (!rendered) return <div className="code-placeholder" />;
+  if (!rendered) return <div class="code-placeholder" />;
 
   return (
     <div
-      className={`my-md flex w-full flex-col gap-[20px] overflow-hidden ${props.allowSideBySide ? "lg:flex-row" : ""} ${props.fullWidth ? "full-width" : ""}`}
+      class={`my-md flex w-full flex-col gap-[20px] overflow-hidden ${props.allowSideBySide ? "lg:flex-row" : ""} ${props.fullWidth ? "full-width" : ""}`}
     >
       {props.previewable ? (
         <div
-          className={`ml-0 flex w-fit gap-[20px] ${largeSketch ? "flex-col" : (props.allowSideBySide ? "" : "flex-col lg:flex-row")}`}
+          class={`ml-0 flex w-fit gap-[20px] ${largeSketch ? "flex-col" : props.allowSideBySide ? "" : "flex-col lg:flex-row"}`}
         >
           <div>
             <CodeFrame
@@ -105,10 +110,16 @@ export const CodeEmbed = (props) => {
               base={props.base}
               frameRef={codeFrameRef}
               lazyLoad={props.lazyLoad}
-	      scripts={props.includeSound ? [cdnLibraryUrl, cdnSoundUrl] :[cdnLibraryUrl]}
+              scripts={
+                props.includeSound
+                  ? [cdnLibraryUrl, cdnSoundUrl]
+                  : [cdnLibraryUrl]
+              }
             />
           </div>
-          <div className={`flex gap-2.5 ${largeSketch ? "flex-row" : "md:flex-row lg:flex-col"}`}>
+          <div
+            class={`flex gap-2.5 ${largeSketch ? "flex-row" : "md:flex-row lg:flex-col"}`}
+          >
             <CircleButton
               className="bg-bg-gray-40"
               onClick={updateOrReRun}
@@ -129,7 +140,7 @@ export const CodeEmbed = (props) => {
           </div>
         </div>
       ) : null}
-      <div className="code-editor-container relative w-full">
+      <div class="code-editor-container relative w-full">
         <CodeMirror
           value={codeString}
           theme="light"
@@ -155,7 +166,7 @@ export const CodeEmbed = (props) => {
             (editorView.contentDOM.ariaLabel = "Code Editor")
           }
         />
-        <div className="absolute right-0 top-0 flex flex-col gap-xs p-xs md:flex-row">
+        <div class="absolute right-0 top-0 flex flex-col gap-xs p-xs md:flex-row">
           <CopyCodeButton textToCopy={codeString || initialCode} />
           <CircleButton
             onClick={() => {

--- a/src/components/CopyCodeButton/index.tsx
+++ b/src/components/CopyCodeButton/index.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'preact/hooks';
-import { useLiveRegion } from '../hooks/useLiveRegion';
+import { useState } from "preact/hooks";
+import { useLiveRegion } from "../hooks/useLiveRegion";
 import CircleButton from "../CircleButton";
 
 interface CopyCodeButtonProps {
@@ -9,56 +9,47 @@ interface CopyCodeButtonProps {
 
 export const CopyCodeButton = ({
   textToCopy,
-  announceOnCopy = 'Code copied to clipboard'
+  announceOnCopy = "Code copied to clipboard",
 }: CopyCodeButtonProps) => {
   const [isCopied, setIsCopied] = useState(false);
 
   const { ref: liveRegionRef, announce } = useLiveRegion<HTMLSpanElement>();
 
   const copyTextToClipboard = async () => {
-    console.log('Copy button clicked');
-    console.log('Text to copy:', textToCopy);
-
     try {
-      console.log('Using Clipboard API');
       await navigator.clipboard.writeText(textToCopy);
-      console.log('Text copied successfully');
 
       announce(announceOnCopy);
 
       setIsCopied(true);
       setTimeout(() => {
         setIsCopied(false);
-        console.log('Copy state reset');
       }, 2000);
     } catch (err) {
-      console.error('Clipboard API copy failed:', err);
+      console.error("Clipboard API copy failed:", err);
     }
   };
 
   return (
     <>
       <CircleButton
-        onClick={() => {
-          console.log('CircleButton clicked');
-          copyTextToClipboard();
-        }}
+        onClick={copyTextToClipboard}
         ariaLabel="Copy code to clipboard"
-        className={`bg-white ${isCopied ? 'text-green-600' : 'text-black'} transition-colors duration-200`}
+        className={`bg-white ${isCopied ? "text-green-600" : "text-black"} transition-colors duration-200`}
       >
         {isCopied ? (
-          <svg 
-            width="18" 
-            height="22" 
-            viewBox="0 0 24 24" 
-            fill="none" 
+          <svg
+            width="18"
+            height="22"
+            viewBox="0 0 24 24"
+            fill="none"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <path 
-              d="M20 6L9 17L4 12" 
-              stroke="currentColor" 
-              strokeWidth="2" 
-              strokeLinecap="round" 
+            <path
+              d="M20 6L9 17L4 12"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
               strokeLinejoin="round"
             />
           </svg>

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -113,13 +113,13 @@ export const Dropdown = ({
   // Render the collapsed dropdown button
   const renderCollapsedDropdown = () => (
     <button
-      className={styles.selected}
+      class={styles.selected}
       onClick={handleDropdownClick}
       aria-haspopup="listbox"
       aria-expanded={isOpen}
       tabIndex={0}
     >
-      <div className={styles.iconTop}>
+      <div class={styles.iconTop}>
         <Icon kind={iconKind} />
       </div>
       <span>
@@ -127,7 +127,7 @@ export const Dropdown = ({
           options.find((option) => isSelected(option))?.label ||
           "Select..."}
       </span>
-      <div className={styles.chevron}>
+      <div class={styles.chevron}>
         <Icon kind="chevron-down" />
       </div>
     </button>
@@ -135,15 +135,15 @@ export const Dropdown = ({
 
   // Render the expanded dropdown options
   const renderExpandedDropdown = () => (
-    <ul className={styles.options} role="listbox" tabIndex={-1}>
+    <ul class={styles.options} role="listbox" tabIndex={-1}>
       {options.map((option, index) => (
         <li
           key={option.value}
-          className={styles.option}
+          class={styles.option}
           role="option"
           aria-selected={isSelected(option)}
         >
-          <div className={styles.icon}>
+          <div class={styles.icon}>
             <Icon
               kind={
                 isSelected(option) ? "option-selected" : "option-unselected"
@@ -162,11 +162,11 @@ export const Dropdown = ({
         </li>
       ))}
       {variant === "radio" ? (
-        <button onClick={() => setIsOpen(false)} className={styles.chevron}>
+        <button onClick={() => setIsOpen(false)} class={styles.chevron}>
           <Icon kind="chevron-up" />
         </button>
       ) : (
-        <div className={styles.chevron}>
+        <div class={styles.chevron}>
           <Icon kind="chevron-up" />
         </div>
       )}
@@ -174,11 +174,7 @@ export const Dropdown = ({
   );
 
   return (
-    <div
-      className={styles.container}
-      ref={dropdownRef}
-      onKeyDown={handleKeyDown}
-    >
+    <div class={styles.container} ref={dropdownRef} onKeyDown={handleKeyDown}>
       {isOpen ? renderExpandedDropdown() : renderCollapsedDropdown()}
     </div>
   );

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -39,7 +39,7 @@ export const Icon = (props: IconProps) => {
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           aria-hidden
-          className={props.className}
+          class={props.className}
         >
           <path
             d="M15.353 0.146446L20.7065 5.5L15.353 10.8536C15.1577 11.0488 14.8411 11.0488 14.6459 10.8536C14.4506 10.6583 14.4506 10.3417 14.6459 10.1464L18.7923 6L4.99951 6C4.72337 6 4.49951 5.77614 4.49951 5.5C4.49951 5.22386 4.72337 5 4.99951 5L18.7923 5L14.6459 0.853553C14.4506 0.658291 14.4506 0.341708 14.6459 0.146446C14.8411 -0.0488155 15.1577 -0.0488155 15.353 0.146446Z"
@@ -55,7 +55,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 61 32"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             d="M45 31L60 16L45 0.999999"
@@ -76,7 +76,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 22 12"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             fill-rule="evenodd"
@@ -94,7 +94,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 7 12"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             fill-rule="evenodd"
@@ -113,7 +113,7 @@ export const Icon = (props: IconProps) => {
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           aria-hidden
-          className={props.className}
+          class={props.className}
         >
           <path
             d="M13.9764 0.718843C14.0606 0.455859 13.9105 0.193701 13.641 0.133296C13.3716 0.0728911 13.0848 0.237114 13.0006 0.500098L7.87626 16.5001C7.79204 16.7631 7.94219 17.0252 8.21165 17.0856C8.4811 17.146 8.76782 16.9818 8.85205 16.7188L13.9764 0.718843Z"
@@ -137,7 +137,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 18 24"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             d="M14.3597 0.745963L15.9691 6.75275L9.96235 8.36232C9.69562 8.43379 9.42145 8.2755 9.34998 8.00877C9.2785 7.74204 9.43679 7.46787 9.70353 7.39639L14.0814 6.22329C12.7385 5.02054 10.9658 4.28984 9.02153 4.28986C4.83114 4.28989 1.43412 7.68694 1.43408 11.8774C1.43408 12.1535 1.21022 12.3774 0.934077 12.3774C0.657935 12.3774 0.43408 12.1535 0.434082 11.8774C0.434122 7.13467 4.27885 3.2899 9.02154 3.28986C11.1249 3.28984 13.0522 4.04653 14.545 5.30172L13.3937 1.00477C13.3223 0.738039 13.4806 0.463872 13.7473 0.392404C14.014 0.320936 14.2882 0.47923 14.3597 0.745963Z"
@@ -157,7 +157,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 16 16"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             d="M15.5 8L0.5 15.5L0.499999 0.500001L15.5 8Z"
@@ -173,7 +173,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 16 16"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <rect x="0.5" y="0.5" width="15" height="15" fill="currentColor" />
         </svg>
@@ -186,7 +186,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             fill-rule="evenodd"
@@ -204,7 +204,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             fill-rule="evenodd"
@@ -222,7 +222,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 20 20"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             fill-rule="evenodd"
@@ -240,7 +240,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 22 12"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             fill-rule="evenodd"
@@ -258,7 +258,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 22 16"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             fill-rule="evenodd"
@@ -282,7 +282,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 21 21"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             fill-rule="evenodd"
@@ -300,7 +300,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 21 11"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             d="M15.3535 0.146446L20.707 5.5L15.3535 10.8536C15.1582 11.0488 14.8416 11.0488 14.6464 10.8536C14.4511 10.6583 14.4511 10.3417 14.6464 10.1464L18.7928 6L5 6C4.72386 6 4.5 5.77614 4.5 5.5C4.5 5.22386 4.72386 5 5 5L18.7928 5L14.6464 0.853553C14.4511 0.658291 14.4511 0.341708 14.6464 0.146446C14.8416 -0.0488155 15.1582 -0.0488155 15.3535 0.146446Z"
@@ -316,7 +316,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 22 18"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             fill-rule="evenodd"
@@ -332,7 +332,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 28 28"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             fill="currentColor"
@@ -349,7 +349,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 17 16"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             fill-rule="evenodd"
@@ -367,7 +367,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 34 34"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             fill-rule="evenodd"
@@ -385,7 +385,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 22 16"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             d="M11.5 0.5L11.5 10.7928L15.6464 6.64637C15.8417 6.45111 16.1583 6.45111 16.3536 6.64637C16.5488 6.84163 16.5488 7.15822 16.3536 7.35348L11 12.707L5.64645 7.35348C5.45118 7.15822 5.45118 6.84163 5.64645 6.64637C5.84171 6.45111 6.15829 6.45111 6.35355 6.64637L10.5 10.7928V0.5C10.5 0.223858 10.7239 0 11 0C11.2761 0 11.5 0.223858 11.5 0.5Z"
@@ -405,7 +405,7 @@ export const Icon = (props: IconProps) => {
           viewBox="0 0 20 15"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className={props.className}
+          class={props.className}
         >
           <path
             fill-rule="evenodd"

--- a/src/components/Nav/MainNavLinks.tsx
+++ b/src/components/Nav/MainNavLinks.tsx
@@ -81,7 +81,7 @@ export const MainNavLinks = ({
       </ul>
       <ul class="flex flex-col gap-[15px]">
         <li>
-          <a className={styles.buttonlink} href="https://editor.p5js.org">
+          <a class={styles.buttonlink} href="https://editor.p5js.org">
             <div class="mr-xxs">
               <Icon kind="code-brackets" />
             </div>
@@ -89,7 +89,7 @@ export const MainNavLinks = ({
           </a>
         </li>
         <li>
-          <a className={styles.buttonlink} href="/donate/">
+          <a class={styles.buttonlink} href="/donate/">
             <div class="mr-xxs">
               <Icon kind="heart" />
             </div>

--- a/src/components/PageHeader/HomePage.astro
+++ b/src/components/PageHeader/HomePage.astro
@@ -7,6 +7,7 @@ interface Props {
   config: CollectionEntry<"homepage">;
 }
 const { config } = Astro.props;
+const heroImages = config.data.heroImages;
 
 ---
 
@@ -22,7 +23,7 @@ const { config } = Astro.props;
       />
     </div>
     {
-      config.data.heroImages.map((im, i) => (
+      heroImages.map((im: typeof heroImages[number], i: number) => (
         <p
           class={`hero-caption text-body-caption pb-sm mt-0 ${i > 0 ? "hidden" : ""}`}
         >
@@ -37,7 +38,7 @@ const { config } = Astro.props;
   </div>
 
   {
-    config.data.heroImages.map((im, i) => (
+    heroImages.map((im: typeof heroImages[number], i: number) => (
       im.linkTarget ?
       <a href={im.linkTarget} class={`max-lg:flex-1 max-lg:min-h-0 hero-image-container ${i > 0 ? "hidden" : ""}`}>
       <Image

--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -116,13 +116,13 @@ export const ReferenceDirectoryWithFilter = ({
               <span class="text-body-mono group-hover:underline">
                 {entry.data.beta && (
                   <div
-                    className="mb-[-2px] mr-2 inline-block h-[16px] w-[16px]"
+                    class="mb-[-2px] mr-2 inline-block h-[16px] w-[16px]"
                     dangerouslySetInnerHTML={{ __html: flask }}
                   />
                 )}
                 {entry.data.deprecated && (
                   <div
-                    className="mb-[-2px] mr-2 inline-block h-[16px] w-[16px]"
+                    class="mb-[-2px] mr-2 inline-block h-[16px] w-[16px]"
                     dangerouslySetInnerHTML={{ __html: warning }}
                   />
                 )}
@@ -160,10 +160,10 @@ export const ReferenceDirectoryWithFilter = ({
             id={subcat.name}
             href={`/reference/${category.name === "p5.sound" ? "p5.sound" : "p5"}/${subcat.name}/`}
           >
-            <h3 className="m-0 py-gutter-md">{subcat.name}</h3>
+            <h3 class="m-0 py-gutter-md">{subcat.name}</h3>
           </a>
         ) : (
-          <h3 className="m-0 py-gutter-md" id={subcat.name}>
+          <h3 class="m-0 py-gutter-md" id={subcat.name}>
             {subcat.name}
           </h3>
         )}

--- a/src/components/RelatedItems/index.astro
+++ b/src/components/RelatedItems/index.astro
@@ -18,12 +18,12 @@ interface Props {
   class?: string;
 }
 
-const { title, items, class: className } = Astro.props;
+const { title, items, class: sectionClass } = Astro.props;
 ---
 
 <div>
   <hr />
-  <section class={className}>
+  <section class={sectionClass}>
     <h2>{title}</h2>
     <ul class="content-grid-simple">
       {items.map((i) => {

--- a/src/components/SearchResults/index.tsx
+++ b/src/components/SearchResults/index.tsx
@@ -28,7 +28,7 @@ const SearchResults = ({
   const [isInputEdited, setInputEdited] = useState(false);
   const prevIsInputEdited = useRef(isInputEdited);
 
-   // Reset filter and input state when search term changes
+  // Reset filter and input state when search term changes
   useEffect(() => {
     setCurrentFilter("");
     setInputEdited(false);
@@ -81,17 +81,17 @@ const SearchResults = ({
     }
 
     return (
-      <div className="flex w-fit py-lg">
-        <p className="mt-0 w-fit text-nowrap">Filter by</p>
-        <ul className="ml-sm flex gap-sm">
+      <div class="flex w-fit py-lg">
+        <p class="mt-0 w-fit text-nowrap">Filter by</p>
+        <ul class="ml-sm flex gap-sm">
           {allUniqueCategoriesForResults.map((category) => (
             <li
               key={category}
-              className={`${currentFilter === category ? "bg-sidebar-type-color text-bg-color" : "bg-bg-color text-sidebar-type-color"} h-[25px] rounded-[20px] border border-sidebar-type-color px-xs py-[0.1rem] hover:bg-sidebar-type-color hover:text-bg-color md:h-[30px]`}
+              class={`${currentFilter === category ? "bg-sidebar-type-color text-bg-color" : "bg-bg-color text-sidebar-type-color"} h-[25px] rounded-[20px] border border-sidebar-type-color px-xs py-[0.1rem] hover:bg-sidebar-type-color hover:text-bg-color md:h-[30px]`}
             >
               <button
                 value={category}
-                className="capitalize"
+                class="capitalize"
                 onClick={() => toggleFilter(category)}
                 aria-pressed={currentFilter === category}
                 aria-label={`Filter by ${uiTranslations[uiTranslationKey(category)]}`}
@@ -114,7 +114,7 @@ const SearchResults = ({
     if (inputRef.current) {
       inputRef.current.value = "";
     }
-    onSearchChange("")
+    onSearchChange("");
   };
   const submitInput = () => {
     if (inputRef.current) {
@@ -181,11 +181,11 @@ const SearchResults = ({
           <div key={category}>
             <hr />
             <h2>{uiTranslations[uiTranslationKey(category)]}</h2>
-            <ul className="mb-4xl mt-lg">
+            <ul class="mb-4xl mt-lg">
               {results
                 .filter((result) => result.category === category)
                 .map((result) => (
-                  <li key={result.id} className="text-body-large my-sm">
+                  <li key={result.id} class="text-body-large my-sm">
                     <a href={result.relativeUrl}>{result.title}</a>
                   </li>
                 ))}
@@ -197,12 +197,12 @@ const SearchResults = ({
   };
 
   return (
-    <div className="py-2xl md:py-3xl">
+    <div class="py-2xl md:py-3xl">
       <div class="sticky top-0 bg-bg-color">
-        <p className="mt-0 pb-xs pt-md">{results.length} results found for</p>
+        <p class="mt-0 pb-xs pt-md">{results.length} results found for</p>
         {renderBigSearchForm()}
       </div>
-      <div className="no-scrollbar w-full overflow-x-scroll">
+      <div class="no-scrollbar w-full overflow-x-scroll">
         {renderFilterByOptions()}
       </div>
 


### PR DESCRIPTION
## Summary
- replace invalid  usage on native markup with 
- keep valid component  props unchanged

## Testing
- 
> p5.js-website@0.0.1 check
> astro check

22:06:33 [astro-mermaid] Setting up Mermaid integration
22:06:33 [astro-mermaid] Existing rehype plugins:
22:06:33 [astro-mermaid] Skipping ELK support
22:06:33 [vite] Re-optimizing dependencies because lockfile has changed
22:06:39 [content] Syncing content
22:06:39 [content] Synced content
22:06:39 [types] Generated 5.27s
22:06:39 [check] Getting diagnostics for Astro files in /home/hxrshxz/Desktop/Projects/harsh/p5.js-website...
[96msrc/components/DonorBoxWidget/index.astro[0m:[93m13[0m:[93m5[0m - [93mwarning[0m[90m ts(6385): [0m'frameborder' is deprecated.

[7m13[0m     frameborder="0"
[7m  [0m [93m    ~~~~~~~~~~~[0m
[96msrc/components/DonorBoxWidget/index.astro[0m:[93m11[0m:[93m5[0m - [93mwarning[0m[90m ts(6385): [0m'scrolling' is deprecated.

[7m11[0m     scrolling="no"
[7m  [0m [93m    ~~~~~~~~~[0m

[96msrc/components/PageHeader/HomePage.astro[0m:[93m67[0m:[93m50[0m - [93mwarning[0m[90m ts(6133): [0m'event' is declared but its value is never read.

[7m67[0m   document.addEventListener("DOMContentLoaded", (event) => {
[7m  [0m [93m                                                 ~~~~~[0m

[96msrc/components/ReferenceDirectoryWithFilter/index.tsx[0m:[93m218[0m:[93m32[0m - [93mwarning[0m[90m ts(6385): [0m'TargetedKeyboardEvent' is deprecated.

[7m218[0m               onKeyUp={(e: JSX.TargetedKeyboardEvent<HTMLInputElement>) => {
[7m   [0m [93m                               ~~~~~~~~~~~~~~~~~~~~~[0m

[96msrc/components/VimeoEmbed/index.astro[0m:[93m5[0m:[93m131[0m - [93mwarning[0m[90m ts(6385): [0m'frameborder' is deprecated.

[7m5[0m <iframe src={`https://player.vimeo.com/video/${props.id}?h=9c6ecb5431&color=f1678e`} title={props.title} width="720" height="405" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
[7m [0m [93m                                                                                                                                  ~~~~~~~~~~~[0m

[96msrc/layouts/ExamplesLayout.astro[0m:[93m59[0m:[93m39[0m - [93mwarning[0m[90m ts(6133): [0m'i' is declared but its value is never read.

[7m59[0m     examplesByCategory.map((category, i) => (
[7m  [0m [93m                                      ~[0m

[96msrc/layouts/ReferenceItemLayout.astro[0m:[93m171[0m:[93m59[0m - [93mwarning[0m[90m ts(6133): [0m'i' is declared but its value is never read.

[7m171[0m             {examples.map(({ src: exampleCode, classes }, i: number) => {
[7m   [0m [93m                                                          ~[0m

[96msrc/layouts/TutorialLayout.astro[0m:[93m8[0m:[93m1[0m - [93mwarning[0m[90m ts(6133): [0m'CodeBlockWrapper' is declared but its value is never read.

[7m8[0m import CodeBlockWrapper from "@components/CodeBlockWrapper/index.astro";
[7m [0m [93m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m

Result (193 files): 
- 0 errors
- 0 warnings
- 8 hints
- 
> p5.js-website@0.0.1 test
> vitest

22:07:00 [astro-mermaid] Setting up Mermaid integration
22:07:00 [astro-mermaid] Existing rehype plugins:
22:07:00 [astro-mermaid] Skipping ELK support
22:07:00 [astro-mermaid] Setting up Mermaid integration
22:07:00 [astro-mermaid] Existing rehype plugins:
22:07:00 [astro-mermaid] Skipping ELK support
22:07:00 [astro-mermaid] Setting up Mermaid integration
22:07:00 [astro-mermaid] Existing rehype plugins:
22:07:00 [astro-mermaid] Skipping ELK support

[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/home/hxrshxz/Desktop/Projects/harsh/p5.js-website[39m

 [32m✓[39m [30m[45m DOM [49m[39m test/basic.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m [30m[45m DOM [49m[39m test/scripts/utils.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m [30m[45m DOM [49m[39m test/scripts/build-search.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m [30m[45m DOM [49m[39m test/i18n/utils.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m [30m[45m DOM [49m[39m test/components/CodeFrame.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[32m 52[2mms[22m[39m
[90mstdout[2m | test/scripts/build-contributor-docs.test.ts
[22m[39mBuilding contributor docs...
Considering cloning repo: https://github.com/processing/p5.js.git branch: v1.11.12 into path: /home/hxrshxz/Desktop/Projects/harsh/p5.js-website/in/p5.js/

[90mstdout[2m | test/scripts/build-contributor-docs.test.ts
[22m[39mRecent version of library repo already exists, skipping clone...

[90mstdout[2m | test/scripts/build-contributor-docs.test.ts
[22m[39mCleaning out current content collection...

 [32m✓[39m [30m[45m DOM [49m[39m test/scripts/build-contributor-docs.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 3[2mms[22m[39m
[90mstdout[2m | test/scripts/build-reference.test.ts
[22m[39mConsidering cloning repo: https://github.com/processing/p5.js.git branch: v1.11.12 into path: /home/hxrshxz/Desktop/Projects/harsh/p5.js-website/src/scripts/parsers/in/p5.js

[90mstdout[2m | test/scripts/build-reference.test.ts
[22m[39mRecent version of library repo already exists, skipping clone...

 [32m✓[39m [30m[45m DOM [49m[39m test/components/CodeEmbed.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[32m 99[2mms[22m[39m
 [32m✓[39m [30m[43m node [49m[39m test/pages/_utils.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m [30m[45m DOM [49m[39m test/scripts/build-reference.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 4[2mms[22m[39m

[2m Test Files [22m [1m[32m9 passed[39m[22m[90m (9)[39m
[2m      Tests [22m [1m[32m36 passed[39m[22m[90m (36)[39m
[2m     Errors [22m [1m[31m2 errors[39m[22m
[2m   Start at [22m 22:07:11
[2m   Duration [22m 23.64s[2m (transform 4.54s, setup 0ms, import 7.38s, tests 187ms, environment 5.74s)[22m (fails on clean  too with existing unhandled errors in contributor docs/reference builder tests)
- 
